### PR TITLE
feat(docs): Use admonitions for collapsible sections

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,19 +8,28 @@ This page provides a detailed API reference for the classes and functions in the
 Imputer Classes
 ***********************
 
-.. autoclass:: datafiller.MultivariateImputer
-   :members: __init__, __call__
-   :undoc-members:
-   :show-inheritance:
+.. admonition:: datafiller.MultivariateImputer
+   :class: dropdown
 
-.. autoclass:: datafiller.TimeSeriesImputer
-   :members: __init__, __call__
-   :undoc-members:
-   :show-inheritance:
+   .. autoclass:: datafiller.MultivariateImputer
+      :members: __init__, __call__
+      :undoc-members:
+      :show-inheritance:
+
+.. admonition:: datafiller.TimeSeriesImputer
+   :class: dropdown
+
+   .. autoclass:: datafiller.TimeSeriesImputer
+      :members: __init__, __call__
+      :undoc-members:
+      :show-inheritance:
 
 ***********************
 Low-Level Functions
 ***********************
 
-.. automodule:: datafiller._optimask
-   :members: optimask
+.. admonition:: datafiller._optimask.optimask
+   :class: dropdown
+
+   .. automodule:: datafiller._optimask
+      :members: optimask

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxawesome_theme.highlighting",
     "myst_parser",
+    "sphinx_togglebutton",
 ]
 
 templates_path = ["_templates"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinxawesome-theme
 pandas
 myst-parser
+sphinx-togglebutton


### PR DESCRIPTION
This commit updates the documentation to use `admonition` directives with the `:class: dropdown` option instead of `.. toggle::`. This allows for custom titles on the toggle buttons, using the class and function names.

This addresses the user's request to have more descriptive toggle buttons in the API reference.