### PR TITLE
ci: bump checkout and setup-python actions in PyPI workflow

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 


### PR DESCRIPTION
Bumps `actions/checkout` v2 → v4 and `actions/setup-python` v2 → v5 in `pypi.yaml`, matching the versions already used in `ci-pipeline.yml`. The v2 actions target a deprecated Node.js runtime (flagged as an annotation on the v0.3.1 publish run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)