### PR TITLE
Test coverage, py.typed, exception hierarchy, and CI hardening

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,6 +1,8 @@
 name: CI Pipeline
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -73,6 +75,55 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -vv -s
+
+  typecheck:
+    # ty is pre-1.0: pinned so a ty release cannot break CI without a code
+    # change. Package dependencies are installed so imports resolve; torch
+    # (CPU) and polars cover the optional-dependency modules.
+    name: Type check (ty)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e ".[polars]" ty==0.0.61
+
+      - name: Type check
+        run: ty check --python "$(which python)" src/datafiller
+
+  coverage:
+    # Runs the suite with numba JIT disabled so coverage.py can trace the
+    # @njit kernels, with CPU-only torch so the non-CUDA GPU-backend tests
+    # run. test_timing.py is skipped: its large workloads are impractically
+    # slow without JIT compilation.
+    name: Coverage (numba JIT disabled)
+    runs-on: ubuntu-latest
+    env:
+      NUMBA_DISABLE_JIT: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e ".[test,polars]"
+
+      - name: Test with coverage
+        run: pytest -q --ignore=tests/test_timing.py --cov=datafiller --cov-report=term-missing --cov-fail-under=85
 
   polars:
     strategy:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,27 @@ Models
       :undoc-members:
       :show-inheritance:
 
+Exceptions
+**********
+
+All validation errors raised by the library derive from
+:class:`~datafiller.DataFillerError`, so a single ``except DataFillerError``
+catches every datafiller-specific error. The concrete classes also inherit
+from the matching builtin (``ValueError`` or ``TypeError``), so existing
+handlers keep working.
+
+.. admonition:: Exception classes
+   :class: dropdown
+
+   .. autoclass:: datafiller.DataFillerError
+      :show-inheritance:
+
+   .. autoclass:: datafiller.DataFillerValueError
+      :show-inheritance:
+
+   .. autoclass:: datafiller.DataFillerTypeError
+      :show-inheritance:
+
 ***********************
 Low-Level Functions
 ***********************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 keywords = ["imputation", "missing-data", "nan", "time-series", "machine-learning"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
@@ -23,7 +23,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
 ]
 dependencies = [
     "numpy>=1.24",
@@ -53,6 +55,7 @@ docs = [
 dev = [
     "datafiller[test]",
     "ruff",
+    "ty",
     "pre-commit",
 ]
 

--- a/src/datafiller/__init__.py
+++ b/src/datafiller/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import version
 
 from .estimators import ExtremeLearningMachine, FastRidge
+from .exceptions import DataFillerError, DataFillerTypeError, DataFillerValueError
 from .multivariate import MultivariateImputer
 from .timeseries import TimeSeriesImputer
 
@@ -9,6 +10,9 @@ __all__ = [
     "TimeSeriesImputer",
     "FastRidge",
     "ExtremeLearningMachine",
+    "DataFillerError",
+    "DataFillerValueError",
+    "DataFillerTypeError",
 ]
 
 __version__ = version("datafiller")

--- a/src/datafiller/_optimask.py
+++ b/src/datafiller/_optimask.py
@@ -8,7 +8,9 @@ imputation model.
 
 import numpy as np
 from numba import bool_, njit, uint32
-from numba.types import UniTuple
+from numba.types import UniTuple  # ty: ignore[unresolved-import]
+
+from .exceptions import DataFillerValueError
 
 
 @njit(bool_(uint32[:]), boundscheck=False, cache=True)
@@ -120,7 +122,7 @@ def _process_index(index: np.ndarray, num: int) -> tuple[np.ndarray, int]:
             table_inv[cnt - 1] = elem
         index[k] = table[elem] - 1
 
-    return table_inv[:cnt], cnt
+    return table_inv[:cnt], int(cnt)
 
 
 def _get_largest_rectangle(heights: np.ndarray, m: int, n: int, min_rows: int = 1) -> tuple[int, int, int]:
@@ -149,10 +151,10 @@ def _get_largest_rectangle(heights: np.ndarray, m: int, n: int, min_rows: int = 
     if min_rows > 1:
         masked = np.where(rows_kept >= min_rows, areas, 0)
         if masked.max() > 0:
-            i0 = np.argmax(masked)
-            return i0, heights[i0], areas[i0]
-    i0 = np.argmax(areas)
-    return i0, heights[i0], areas[i0]
+            i0 = int(np.argmax(masked))
+            return i0, int(heights[i0]), int(areas[i0])
+    i0 = int(np.argmax(areas))
+    return i0, int(heights[i0]), int(areas[i0])
 
 
 def optimask(
@@ -225,7 +227,7 @@ def optimask(
             is_pareto_ordered = is_decreasing(hy)
 
     if not is_pareto_ordered:
-        raise ValueError(f"Pareto optimization did not converge after {step} steps.")
+        raise DataFillerValueError(f"Pareto optimization did not converge after {step} steps.")
 
     # Find the largest rectangle in the pareto-optimal ordering
     i0, j0, area = _get_largest_rectangle(hx, len(rows), len(cols), min_rows=min_rows)

--- a/src/datafiller/datasets/_misc.py
+++ b/src/datafiller/datasets/_misc.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
 
+from ..exceptions import DataFillerValueError
+
 
 def add_mar(df: pd.DataFrame, nan_ratio: float, rng: int | np.random.Generator | None = None) -> pd.DataFrame:
     """Add Missing At Random (MAR) values to a DataFrame.
@@ -17,7 +19,7 @@ def add_mar(df: pd.DataFrame, nan_ratio: float, rng: int | np.random.Generator |
         ValueError: If nan_ratio is not between 0 and 1
     """
     if not 0 <= nan_ratio <= 1:
-        raise ValueError("nan_ratio must be between 0 and 1")
+        raise DataFillerValueError("nan_ratio must be between 0 and 1")
 
     gen = np.random.default_rng(rng)
     df_copy = df.copy()
@@ -44,7 +46,7 @@ def add_contiguous_missing(
         ValueError: If frac_columns or length are invalid
     """
     if not 0 <= frac_columns <= 1:
-        raise ValueError("frac_columns must be between 0 and 1")
+        raise DataFillerValueError("frac_columns must be between 0 and 1")
 
     gen = np.random.default_rng(rng)
     df_copy = df.copy()

--- a/src/datafiller/exceptions.py
+++ b/src/datafiller/exceptions.py
@@ -1,0 +1,27 @@
+"""Exception classes raised by datafiller.
+
+All validation errors raised by the package derive from :class:`DataFillerError`,
+so callers can catch every datafiller-specific error with a single handler::
+
+    from datafiller import DataFillerError, MultivariateImputer
+
+    try:
+        MultivariateImputer()(x)
+    except DataFillerError:
+        ...
+
+The concrete classes also inherit from the matching builtin (:class:`ValueError`
+or :class:`TypeError`), so existing ``except ValueError`` handlers keep working.
+"""
+
+
+class DataFillerError(Exception):
+    """Base class for all errors raised by datafiller."""
+
+
+class DataFillerValueError(DataFillerError, ValueError):
+    """A datafiller error raised for invalid argument values."""
+
+
+class DataFillerTypeError(DataFillerError, TypeError):
+    """A datafiller error raised for arguments of an unsupported type."""

--- a/src/datafiller/multivariate/_polars.py
+++ b/src/datafiller/multivariate/_polars.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import numpy as np
 
+from ..exceptions import DataFillerValueError
+
 
 def _get_polars():
     import polars
@@ -32,18 +34,21 @@ def polars_cols_to_indices(cols_to_impute, columns: list[str]) -> np.ndarray:
     if cols_to_impute is None:
         return np.arange(len(columns))
 
-    names = (
+    requested = (
         [cols_to_impute]
         if isinstance(cols_to_impute, str) or not isinstance(cols_to_impute, Iterable)
         else list(cols_to_impute)
     )
-    if not all(isinstance(name, str) for name in names):
-        raise ValueError("cols_to_impute must contain Polars column names as strings.")
+    names: list[str] = []
+    for name in requested:
+        if not isinstance(name, str):
+            raise DataFillerValueError("cols_to_impute must contain Polars column names as strings.")
+        names.append(name)
 
     positions = {name: i for i, name in enumerate(columns)}
     missing = [name for name in names if name not in positions]
     if missing:
-        raise ValueError(f"Column names not found in Polars DataFrame: {missing}")
+        raise DataFillerValueError(f"Column names not found in Polars DataFrame: {missing}")
     return np.array([positions[name] for name in names], dtype=np.int64)
 
 
@@ -54,10 +59,10 @@ def validate_polars_rows(rows_to_impute, height: int):
     if isinstance(rows_to_impute, np.ndarray):
         return rows_to_impute
     if isinstance(rows_to_impute, str) or not isinstance(rows_to_impute, Iterable):
-        raise ValueError("rows_to_impute must contain integer row positions for a Polars DataFrame.")
+        raise DataFillerValueError("rows_to_impute must contain integer row positions for a Polars DataFrame.")
     rows = list(rows_to_impute)
     if not all(isinstance(row, (int, np.integer)) and 0 <= row < height for row in rows):
-        raise ValueError(f"rows_to_impute must contain integer row positions between 0 and {height - 1}.")
+        raise DataFillerValueError(f"rows_to_impute must contain integer row positions between 0 and {height - 1}.")
     return rows
 
 
@@ -107,7 +112,7 @@ def encode_polars_dataframe(df) -> dict:
             encoded_arrays.append(series.cast(pl.Float32).to_numpy().reshape(-1, 1))
             numeric_main_indices.append(main_idx)
         else:
-            raise ValueError(
+            raise DataFillerValueError(
                 f"Unsupported Polars dtype for column {col!r}: {dtype}. "
                 "Supported dtypes are numeric, Boolean, String, Categorical, and Enum."
             )
@@ -137,7 +142,7 @@ def decode_polars_dataframe(x_imputed: np.ndarray, metadata: dict):
 
         if encoded_idx in metadata["categorical_targets"]:
             categories = metadata["categorical_targets"][encoded_idx]
-            decoded = [None] * len(col_data)
+            decoded: list[Any] = [None] * len(col_data)
             if categories:
                 for row, value in enumerate(col_data):
                     if np.isfinite(value):

--- a/src/datafiller/multivariate/_utils.py
+++ b/src/datafiller/multivariate/_utils.py
@@ -4,8 +4,10 @@ from collections.abc import Iterable
 
 import numpy as np
 
+from ..exceptions import DataFillerValueError
 
-def _process_to_impute(size: int, to_impute: None | int | Iterable[int]) -> np.ndarray:
+
+def _process_to_impute(size: int, to_impute: None | int | Iterable) -> np.ndarray:
     """Processes the `to_impute` argument into a numpy array of indices.
 
     Args:
@@ -36,7 +38,7 @@ def _dataframe_rows_to_impute_to_indices(rows_to_impute, index):
 
     if np.any((indexer := index.get_indexer(to_impute_list)) == -1):
         missing = [label for label, i in zip(to_impute_list, indexer, strict=True) if i == -1]
-        raise ValueError(f"Row labels not found in index: {missing}")
+        raise DataFillerValueError(f"Row labels not found in index: {missing}")
     return indexer
 
 
@@ -53,16 +55,16 @@ def _dataframe_cols_to_impute_to_indices(cols_to_impute, columns):
 
     if np.any((indexer := columns.get_indexer(to_impute_list)) == -1):
         missing = [label for label, i in zip(to_impute_list, indexer, strict=True) if i == -1]
-        raise ValueError(f"Column labels not found in columns: {missing}")
+        raise DataFillerValueError(f"Column labels not found in columns: {missing}")
     return indexer
 
 
 def _validate_input(
     x: np.ndarray,
-    rows_to_impute: None | int | Iterable[int],
-    cols_to_impute: None | int | Iterable[int],
+    rows_to_impute: None | int | Iterable,
+    cols_to_impute: None | int | Iterable,
     n_nearest_features: None | float | int,
-) -> int:
+) -> int | None:
     """Validates the inputs to the `__call__` method.
 
     Args:
@@ -78,13 +80,13 @@ def _validate_input(
         ValueError: If any of the inputs are invalid.
     """
     if not isinstance(x, np.ndarray):
-        raise ValueError("x must be a numpy array.")
+        raise DataFillerValueError("x must be a numpy array.")
     if x.ndim != 2:
-        raise ValueError(f"x must be a 2D array, but got {x.ndim} dimensions.")
+        raise DataFillerValueError(f"x must be a 2D array, but got {x.ndim} dimensions.")
     if not np.issubdtype(x.dtype, np.number):
-        raise ValueError(f"x must have a numeric dtype, but got {x.dtype}.")
+        raise DataFillerValueError(f"x must have a numeric dtype, but got {x.dtype}.")
     if np.isinf(x).any():
-        raise ValueError("x cannot contain infinity.")
+        raise DataFillerValueError("x cannot contain infinity.")
 
     m, n = x.shape
 
@@ -93,11 +95,13 @@ def _validate_input(
             rows_to_impute = [rows_to_impute]
         if isinstance(rows_to_impute, np.ndarray):
             if not np.issubdtype(rows_to_impute.dtype, np.integer):
-                raise ValueError(f"rows_to_impute must have an integer dtype, but got {rows_to_impute.dtype}.")
-            if not (np.all(rows_to_impute >= 0) and np.all(rows_to_impute < m)):
-                raise ValueError(f"rows_to_impute must be a list of integers between 0 and {m - 1}.")
+                raise DataFillerValueError(
+                    f"rows_to_impute must have an integer dtype, but got {rows_to_impute.dtype}."
+                )
+            if not (np.all(rows_to_impute >= 0) and np.all(rows_to_impute < m)):  # ty: ignore[unsupported-operator]
+                raise DataFillerValueError(f"rows_to_impute must be a list of integers between 0 and {m - 1}.")
         elif not all(isinstance(i, int) for i in rows_to_impute) or not all(0 <= i < m for i in rows_to_impute):
-            raise ValueError(f"rows_to_impute must be a list of integers between 0 and {m - 1}.")
+            raise DataFillerValueError(f"rows_to_impute must be a list of integers between 0 and {m - 1}.")
 
     if cols_to_impute is not None:
         if isinstance(cols_to_impute, int):
@@ -105,18 +109,18 @@ def _validate_input(
         if not all(isinstance(i, (int, np.integer)) for i in cols_to_impute) or not all(
             0 <= i < n for i in cols_to_impute
         ):
-            raise ValueError(f"cols_to_impute must be a list of integers between 0 and {n - 1}.")
+            raise DataFillerValueError(f"cols_to_impute must be a list of integers between 0 and {n - 1}.")
 
     if n_nearest_features is not None:
         if isinstance(n_nearest_features, float):
             if not (0 < n_nearest_features <= 1.0):
-                raise ValueError("If n_nearest_features is a float, it must be in (0, 1].")
+                raise DataFillerValueError("If n_nearest_features is a float, it must be in (0, 1].")
             n_nearest_features = int(n_nearest_features * n)
             if n_nearest_features == 0:
-                raise ValueError("n_nearest_features resulted in 0 features to select.")
+                raise DataFillerValueError("n_nearest_features resulted in 0 features to select.")
         if not isinstance(n_nearest_features, int):
-            raise ValueError("n_nearest_features must be an int or float.")
+            raise DataFillerValueError("n_nearest_features must be an int or float.")
         if not (0 < n_nearest_features <= n):
-            raise ValueError(f"n_nearest_features must be between 1 and {n}.")
+            raise DataFillerValueError(f"n_nearest_features must be between 1 and {n}.")
 
     return n_nearest_features

--- a/src/datafiller/multivariate/imputer.py
+++ b/src/datafiller/multivariate/imputer.py
@@ -2,6 +2,7 @@
 
 import warnings
 from collections.abc import Callable, Iterable
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -12,6 +13,7 @@ from tqdm.auto import tqdm
 
 from .._optimask import optimask
 from ..estimators.ridge import FastRidge, fit_ridge_from_gram
+from ..exceptions import DataFillerTypeError, DataFillerValueError
 from ._gpu import GramBackend
 from ._numba_utils import (
     _imputable_rows,
@@ -151,7 +153,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
     @staticmethod
     def _validate_fallback(fallback: str | None) -> str | None:
         if fallback not in (None, "simple"):
-            raise ValueError(f"fallback must be 'simple' or None, got {fallback!r}")
+            raise DataFillerValueError(f"fallback must be 'simple' or None, got {fallback!r}")
         return fallback
 
     def __init__(
@@ -176,23 +178,22 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
             device: Optional torch device (e.g. ``"cuda"``) for batched ridge solves.
         """
         self._regressor_default = regressor is None
-        self.regressor = regressor or FastRidge()
+        # Regressors and classifiers are sklearn-compatible duck types; the
+        # mixin base classes do not declare fit/predict, hence Any.
+        self.regressor: Any = regressor or FastRidge()
         self.verbose = int(verbose)
         self.min_samples_train = self._resolve_min_samples_train(min_samples_train)
         self.fallback = self._validate_fallback(fallback)
         self.rng = rng
         self._rng = np.random.RandomState(rng)
         self._classifier_default = classifier is None
-        self.classifier = classifier or DecisionTreeClassifier(max_depth=4, random_state=rng)
-        if scoring == "default":
-            self.scoring = scoring
-        elif callable(scoring):
-            self.scoring = scoring
-        else:
-            raise ValueError("`scoring` must be 'default' or a callable.")
+        self.classifier: Any = classifier or DecisionTreeClassifier(max_depth=4, random_state=rng)
+        if scoring != "default" and not callable(scoring):
+            raise DataFillerValueError("`scoring` must be 'default' or a callable.")
+        self.scoring: str | Callable[..., np.ndarray] = scoring
         self.device = device
-        self._gpu_backend = None
-        self.imputation_features_ = None
+        self._gpu_backend: GramBackend | None = None
+        self.imputation_features_: dict | None = None
 
     def fit(self, X, y: None = None) -> "MultivariateImputer":
         """No-op fit for sklearn compatibility."""
@@ -262,6 +263,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
             # The scores are for all n_features, but we are sampling from n_features - 1
             # The scores array is (n_cols_to_impute, n_features)
             # The scores for the column to impute against itself should be 0 or NaN.
+            assert scores is not None
             p = scores[scores_index][cols_to_sample_from]
             p = p / p.sum()
             p[np.isnan(p)] = 0
@@ -510,7 +512,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
         col_ptr, col_rows = nan_cols_csc(local_iy, local_ix, k_local)
         hits = np.zeros(m_local, dtype=np.uint32)
         stamp = np.full(m_local, -1, dtype=np.int64)
-        epoch = 0
+        epoch = np.int64(0)
 
         # The Gram of `[X, y, 1]` is accumulated once over the globally
         # complete rows; each pattern then only adds a small correction.
@@ -523,7 +525,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
             z0 = z_aug if len(complete0) == m_local else z_aug[complete0]
             gram0 = z0.T @ z0
 
-        training_groups = {}
+        training_groups: dict[tuple, dict[str, Any]] = {}
         for pattern, prediction_group in zip(patterns, prediction_groups, strict=False):
             usable_cols_local = local_cols[pattern].astype(np.uint32, copy=False)
             if not len(usable_cols_local):
@@ -637,6 +639,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
         on ``self.device``; patterns with fewer than `min_samples_train`
         complete rows fall back to the CPU optimask branch below.
         """
+        assert self._gpu_backend is not None
         result = self._gpu_backend.impute_column(
             x=x,
             col=col_to_impute,
@@ -652,6 +655,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
             x_imputed[imputable_rows[rows_solved], col_to_impute] = result.predictions[rows_solved]
         if result.all_valid:
             return
+        assert result.patterns is not None and result.indexes is not None and result.pattern_valid is not None
 
         sampled_cols_uint32 = sampled_cols.astype(np.uint32, copy=False)
         local_train = _subset(X=x, rows=trainable_rows, columns=sampled_cols_uint32)
@@ -755,7 +759,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
             (NumPy array, pandas DataFrame, or Polars DataFrame).
         """
         if is_polars_lazyframe(x):
-            raise TypeError("Polars LazyFrame input is not supported; call collect() before imputation.")
+            raise DataFillerTypeError("Polars LazyFrame input is not supported; call collect() before imputation.")
 
         is_pandas_df = isinstance(x, pd.DataFrame)
         is_polars_df = is_polars_dataframe(x)
@@ -817,8 +821,11 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
         if normalize:
             if is_df:
                 if is_polars_df:
+                    assert polars_metadata is not None
                     normalize_cols = polars_metadata["numeric_main_indices"]
                 else:
+                    assert original_columns is not None and original_dtypes is not None
+                    assert main_column_indices is not None
                     numeric_cols = []
                     for i, col in enumerate(original_columns):
                         dtype = original_dtypes[col]
@@ -839,7 +846,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
                     x[:, normalize_cols] = (x[:, normalize_cols] - norm_means) / norm_scales
 
         if n_nearest_features is not None:
-            if self.scoring == "default":
+            if isinstance(self.scoring, str):
                 scores = scoring(x, cols_to_impute, mask_nan)
             else:
                 scores = self.scoring(x, cols_to_impute)
@@ -898,6 +905,8 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
             }
 
         if is_pandas_df:
+            assert isinstance(original_index, pd.Index) and isinstance(original_columns, pd.Index)
+            assert main_column_indices is not None and original_dtypes is not None
             return self._decode_dataframe(
                 x_imputed=x_imputed,
                 original_index=original_index,
@@ -907,6 +916,7 @@ class MultivariateImputer(BaseEstimator, TransformerMixin):
                 original_dtypes=original_dtypes,
             )
         if is_polars_df:
+            assert polars_metadata is not None
             return decode_polars_dataframe(x_imputed, polars_metadata)
 
         return x_imputed

--- a/src/datafiller/timeseries/_utils.py
+++ b/src/datafiller/timeseries/_utils.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+from ..exceptions import DataFillerTypeError
+
 
 def interpolate_small_gaps(series: pd.Series, n: int) -> pd.Series:
     """Interpolate missing values (NaN) in a Pandas Series,
@@ -13,7 +15,7 @@ def interpolate_small_gaps(series: pd.Series, n: int) -> pd.Series:
         pd.Series: The Series with small gaps interpolated.
     """
     if not isinstance(n, int):
-        raise TypeError("n must be an int")
+        raise DataFillerTypeError("n must be an int")
     is_nan = series.isna()
     gaps = (is_nan != is_nan.shift()).cumsum()
     mask = series.groupby(gaps).transform("size") <= n

--- a/src/datafiller/timeseries/imputer.py
+++ b/src/datafiller/timeseries/imputer.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
 
+from ..exceptions import DataFillerTypeError, DataFillerValueError
 from ..multivariate._polars import is_polars_dataframe, is_polars_lazyframe
 from ..multivariate.imputer import MultivariateImputer
 from ._utils import interpolate_small_gaps
@@ -93,17 +94,17 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
         rng: int | None = None,
         verbose: int = 0,
         scoring: str | Callable = "default",
-        interpolate_gaps_less_than: int = None,
+        interpolate_gaps_less_than: int | None = None,
         add_time_features: bool = True,
         device: str | None = None,
         time_column: str | None = None,
     ):
         if not isinstance(lags, Iterable) or not all(isinstance(i, int) for i in lags):
-            raise ValueError("lags must be an iterable of integers.")
+            raise DataFillerValueError("lags must be an iterable of integers.")
         if 0 in lags:
-            raise ValueError("lags cannot contain 0.")
+            raise DataFillerValueError("lags cannot contain 0.")
         if time_column is not None and not isinstance(time_column, str):
-            raise ValueError("time_column must be a string or None.")
+            raise DataFillerValueError("time_column must be a string or None.")
         self.lags = lags
         self.regressor = regressor
         self.classifier = classifier
@@ -142,7 +143,7 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
     def set_params(self, **params) -> "TimeSeriesImputer":
         """Set parameters and refresh dependent objects."""
         if "time_column" in params and params["time_column"] is not None and not isinstance(params["time_column"], str):
-            raise ValueError("time_column must be a string or None.")
+            raise DataFillerValueError("time_column must be a string or None.")
         rebuild_keys = {
             "regressor",
             "classifier",
@@ -169,30 +170,31 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
             return index.freq
 
         if len(index) < 2:
-            raise ValueError("DataFrame index must have a frequency or at least two timestamps to infer one.")
+            raise DataFillerValueError("DataFrame index must have a frequency or at least two timestamps to infer one.")
         if len(index) >= 3:
             inferred = pd.infer_freq(index)
             if inferred is not None:
                 return inferred
         if not index.is_monotonic_increasing:
-            raise ValueError("DataFrame index must be sorted in increasing order.")
+            raise DataFillerValueError("DataFrame index must be sorted in increasing order.")
         if index.has_duplicates:
-            raise ValueError("DataFrame index must not contain duplicate timestamps.")
+            raise DataFillerValueError("DataFrame index must not contain duplicate timestamps.")
 
         timestamps_ns = index.to_numpy(dtype="datetime64[ns]").astype(np.int64)
         deltas = np.diff(timestamps_ns)
         positive_deltas = deltas[deltas > 0]
         if not positive_deltas.size:
-            raise ValueError("DataFrame index frequency could not be inferred.")
+            raise DataFillerValueError("DataFrame index frequency could not be inferred.")
 
         base_delta = positive_deltas.min()
         if np.any(positive_deltas % base_delta != 0):
-            raise ValueError("DataFrame index frequency could not be inferred from irregular timestamp gaps.")
+            raise DataFillerValueError("DataFrame index frequency could not be inferred from irregular timestamp gaps.")
         return pd.Timedelta(base_delta, unit="ns")
 
     @classmethod
     def _regularize_index(cls, df: pd.DataFrame) -> pd.DataFrame:
         """Reindex a time series to its complete regular timestamp grid."""
+        assert isinstance(df.index, pd.DatetimeIndex)
         freq = cls._infer_frequency(df.index)
         full_index = pd.date_range(start=df.index[0], end=df.index[-1], freq=freq, name=df.index.name)
         if len(full_index) == len(df.index) and full_index.equals(df.index):
@@ -208,9 +210,9 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
         else:
             trend = np.zeros(len(index), dtype=np.float32)
 
-        hour = index.hour.to_numpy(dtype=np.float32) + index.minute.to_numpy(dtype=np.float32) / 60.0
+        hour = index.hour.to_numpy(dtype=np.float32) + index.minute.to_numpy(dtype=np.float32) / 60.0  # ty: ignore[unresolved-attribute]
         day_angle = np.float32(2.0 * np.pi) * hour / np.float32(24.0)
-        week_angle = np.float32(2.0 * np.pi) * index.dayofweek.to_numpy(dtype=np.float32) / np.float32(7.0)
+        week_angle = np.float32(2.0 * np.pi) * index.dayofweek.to_numpy(dtype=np.float32) / np.float32(7.0)  # ty: ignore[unresolved-attribute]
 
         base_features = {
             "__time_trend": trend.astype(np.float32, copy=False),
@@ -237,25 +239,29 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
         import polars as pl
 
         if self.time_column is None:
-            raise ValueError("time_column must be set when TimeSeriesImputer receives a Polars DataFrame.")
+            raise DataFillerValueError("time_column must be set when TimeSeriesImputer receives a Polars DataFrame.")
         if self.time_column not in df.columns:
-            raise ValueError(f"time_column {self.time_column!r} was not found in the Polars DataFrame.")
+            raise DataFillerValueError(f"time_column {self.time_column!r} was not found in the Polars DataFrame.")
 
         time_series = df.get_column(self.time_column)
         if time_series.dtype.base_type() not in {pl.Date, pl.Datetime}:
-            raise TypeError(
+            raise DataFillerTypeError(
                 f"Polars time_column must have Date or Datetime dtype, got {time_series.dtype} for "
                 f"{self.time_column!r}."
             )
         if time_series.null_count():
-            raise ValueError("Polars time_column cannot contain null values.")
+            raise DataFillerValueError("Polars time_column cannot contain null values.")
 
         data_columns = [column for column in df.columns if column != self.time_column]
         if not data_columns:
-            raise ValueError("A Polars time series must contain at least one data column besides time_column.")
+            raise DataFillerValueError(
+                "A Polars time series must contain at least one data column besides time_column."
+            )
         unsupported = [column for column in data_columns if not df.schema[column].is_numeric()]
         if unsupported:
-            raise ValueError(f"TimeSeriesImputer requires numeric data columns; unsupported columns: {unsupported}")
+            raise DataFillerValueError(
+                f"TimeSeriesImputer requires numeric data columns; unsupported columns: {unsupported}"
+            )
 
         index = pd.DatetimeIndex(time_series.to_list(), name=self.time_column)
         data = {column: df.get_column(column).to_numpy() for column in data_columns}
@@ -318,7 +324,7 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
         positions = index.get_indexer(timestamps)
         if np.any(positions == -1):
             missing = [value for value, position in zip(values, positions, strict=True) if position == -1]
-            raise ValueError(f"Timestamps not found in the regularized time grid: {missing}")
+            raise DataFillerValueError(f"Timestamps not found in the regularized time grid: {missing}")
         return positions
 
     def __call__(
@@ -366,7 +372,7 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
                 gaps), or if the columns are not numeric.
         """
         if is_polars_lazyframe(df):
-            raise TypeError("Polars LazyFrame input is not supported; call collect() before imputation.")
+            raise DataFillerTypeError("Polars LazyFrame input is not supported; call collect() before imputation.")
         is_polars_df = is_polars_dataframe(df)
         polars_metadata = None
         if is_polars_df:
@@ -374,11 +380,12 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
             df, polars_metadata = self._polars_to_pandas(df)
         else:
             if not isinstance(df, pd.DataFrame):
-                raise TypeError("Input must be a pandas or eager Polars DataFrame.")
+                raise DataFillerTypeError("Input must be a pandas or eager Polars DataFrame.")
             if not isinstance(df.index, pd.DatetimeIndex):
-                raise TypeError("DataFrame index must be a DatetimeIndex.")
+                raise DataFillerTypeError("DataFrame index must be a DatetimeIndex.")
 
         df = self._regularize_index(df)
+        assert isinstance(df.index, pd.DatetimeIndex)
 
         if is_polars_df:
             rows_to_impute = self._polars_rows_to_indices(polars_rows_to_impute, df.index)
@@ -389,9 +396,9 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
                     else list(cols_to_impute)
                 )
                 if not all(isinstance(column, str) for column in requested_columns):
-                    raise ValueError("cols_to_impute must contain column names for a Polars DataFrame.")
+                    raise DataFillerValueError("cols_to_impute must contain column names for a Polars DataFrame.")
                 if self.time_column in requested_columns:
-                    raise ValueError("The Polars time_column cannot be imputed.")
+                    raise DataFillerValueError("The Polars time_column cannot be imputed.")
 
         if self.interpolate_gaps_less_than is not None:
             df = df.copy()
@@ -406,7 +413,7 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
             try:
                 values = values.astype(np.float64)
             except (TypeError, ValueError) as exc:
-                raise ValueError("TimeSeriesImputer requires numeric columns.") from exc
+                raise DataFillerValueError("TimeSeriesImputer requires numeric columns.") from exc
 
         # Create autoregressive (and optional calendar) features directly in a
         # preallocated matrix instead of concatenating shifted DataFrames.
@@ -415,6 +422,7 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
         for lag in lags:
             feature_names.extend(f"{col}_lag_{lag}" for col in original_cols)
         if self.add_time_features:
+            assert isinstance(df.index, pd.DatetimeIndex)
             time_features = self._make_time_features(df.index, reserved_names=feature_names)
             feature_names.extend(time_features.columns)
         else:
@@ -457,7 +465,7 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
                 elif isinstance(c, str):
                     indices.append(original_cols.get_loc(c))
                 else:
-                    raise ValueError("cols_to_impute must be an int, str, or an iterable of ints or strs.")
+                    raise DataFillerValueError("cols_to_impute must be an int, str, or an iterable of ints or strs.")
             cols_to_impute_indices = np.array(indices)
 
         # Process rows_to_impute
@@ -496,7 +504,13 @@ class TimeSeriesImputer(BaseEstimator, TransformerMixin):
             positions = feature_index.get_indexer(original_cols)
             if (positions >= 0).all():
                 result = pd.DataFrame(imputed_data[:, positions], index=df.index, columns=original_cols)
-                return self._pandas_to_polars(result, polars_metadata) if is_polars_df else result
+                if is_polars_df:
+                    assert polars_metadata is not None
+                    return self._pandas_to_polars(result, polars_metadata)
+                return result
         imputed_df = pd.DataFrame(imputed_data, index=df.index, columns=feature_index)
         result = imputed_df[original_cols]
-        return self._pandas_to_polars(result, polars_metadata) if is_polars_df else result
+        if is_polars_df:
+            assert polars_metadata is not None
+            return self._pandas_to_polars(result, polars_metadata)
+        return result

--- a/tests/test_datasets_misc.py
+++ b/tests/test_datasets_misc.py
@@ -1,0 +1,78 @@
+"""Tests for the synthetic missingness helpers in datafiller.datasets."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datafiller.datasets import add_contiguous_missing, add_mar
+
+
+@pytest.fixture
+def df():
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(rng.normal(size=(200, 8)), columns=[f"col_{i}" for i in range(8)])
+
+
+@pytest.mark.parametrize("nan_ratio", [-0.1, 1.5])
+def test_add_mar_invalid_ratio_raises(df, nan_ratio):
+    with pytest.raises(ValueError, match="nan_ratio must be between 0 and 1"):
+        add_mar(df, nan_ratio=nan_ratio)
+
+
+def test_add_mar_hits_requested_ratio(df):
+    result = add_mar(df, nan_ratio=0.3, rng=0)
+    observed_ratio = result.isna().to_numpy().mean()
+    assert observed_ratio == pytest.approx(0.3, abs=0.05)
+    assert not df.isna().any().any(), "input DataFrame must not be modified"
+
+
+@pytest.mark.parametrize("nan_ratio, expected", [(0.0, 0.0), (1.0, 1.0)])
+def test_add_mar_boundary_ratios(df, nan_ratio, expected):
+    result = add_mar(df, nan_ratio=nan_ratio, rng=0)
+    assert result.isna().to_numpy().mean() == expected
+
+
+def test_add_mar_reproducible_with_seed(df):
+    first = add_mar(df, nan_ratio=0.2, rng=42)
+    second = add_mar(df, nan_ratio=0.2, rng=42)
+    pd.testing.assert_frame_equal(first, second)
+
+
+@pytest.mark.parametrize("frac_columns", [-0.1, 1.5])
+def test_add_contiguous_missing_invalid_frac_raises(df, frac_columns):
+    with pytest.raises(ValueError, match="frac_columns must be between 0 and 1"):
+        add_contiguous_missing(df, frac_columns=frac_columns, length=10)
+
+
+def test_add_contiguous_missing_int_length(df):
+    result = add_contiguous_missing(df, frac_columns=0.5, length=10, rng=0)
+
+    modified = [col for col in df.columns if result[col].isna().any()]
+    assert len(modified) == 4  # half of the 8 columns
+    assert not df.isna().any().any(), "input DataFrame must not be modified"
+    for col in modified:
+        nan_positions = np.flatnonzero(result[col].isna().to_numpy())
+        assert len(nan_positions) == 10
+        assert np.array_equal(nan_positions, np.arange(nan_positions[0], nan_positions[0] + 10)), (
+            f"missing block in {col} is not contiguous"
+        )
+
+
+def test_add_contiguous_missing_float_length(df):
+    result = add_contiguous_missing(df, frac_columns=0.25, length=0.1, rng=0)
+
+    modified = [col for col in df.columns if result[col].isna().any()]
+    assert len(modified) == 2
+    for col in modified:
+        assert result[col].isna().sum() == 20  # 10% of 200 rows
+
+
+def test_add_contiguous_missing_length_capped_at_n_rows(df):
+    result = add_contiguous_missing(df, frac_columns=1.0, length=10_000, rng=0)
+    assert result.isna().all().all()
+
+
+def test_add_contiguous_missing_reproducible_with_seed(df):
+    first = add_contiguous_missing(df, frac_columns=0.5, length=15, rng=7)
+    second = add_contiguous_missing(df, frac_columns=0.5, length=15, rng=7)
+    pd.testing.assert_frame_equal(first, second)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,206 @@
+"""Error-path tests: every user-facing validation error should be pinned by a test.
+
+Grouped by the surface that raises: MultivariateImputer configuration, input
+validation for arrays and pandas DataFrames, and TimeSeriesImputer validation.
+Polars-specific error paths live in the ``*_polars.py`` test modules.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from datafiller import (
+    DataFillerError,
+    DataFillerTypeError,
+    DataFillerValueError,
+    MultivariateImputer,
+    TimeSeriesImputer,
+)
+from datafiller.multivariate._utils import _validate_input
+from datafiller.timeseries._utils import interpolate_small_gaps
+
+
+@pytest.fixture
+def x_valid():
+    return np.arange(30, dtype=np.float64).reshape(10, 3)
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_exception_hierarchy():
+    assert issubclass(DataFillerValueError, DataFillerError)
+    assert issubclass(DataFillerValueError, ValueError)
+    assert issubclass(DataFillerTypeError, DataFillerError)
+    assert issubclass(DataFillerTypeError, TypeError)
+
+
+def test_validation_errors_are_catchable_as_datafiller_error():
+    with pytest.raises(DataFillerError):
+        MultivariateImputer()(np.array([1.0, 2.0]))
+    with pytest.raises(DataFillerError):
+        TimeSeriesImputer()(pd.DataFrame({"a": [1.0, 2.0]}))
+
+
+# ---------------------------------------------------------------------------
+# MultivariateImputer configuration
+# ---------------------------------------------------------------------------
+
+
+def test_multivariate_imputer_invalid_scoring_raises():
+    with pytest.raises(ValueError, match="scoring"):
+        MultivariateImputer(scoring="mse")
+
+
+# ---------------------------------------------------------------------------
+# MultivariateImputer input validation (numpy)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_input_rejects_non_numpy():
+    with pytest.raises(ValueError, match="numpy array"):
+        _validate_input([[1.0, 2.0]], None, None, None)
+
+
+@pytest.mark.parametrize(
+    "x, match",
+    [
+        (np.array([1.0, 2.0, 3.0]), "2D array"),
+        (np.array([["a", "b"], ["c", "d"]]), "numeric dtype"),
+        (np.array([[1.0, np.inf], [2.0, 3.0]]), "infinity"),
+    ],
+)
+def test_multivariate_imputer_invalid_x_raises(x, match):
+    with pytest.raises(ValueError, match=match):
+        MultivariateImputer()(x)
+
+
+@pytest.mark.parametrize(
+    "rows, match",
+    [
+        (np.array([0.5, 1.5]), "integer dtype"),
+        (np.array([0, 100]), "between 0 and 9"),
+        ([0, 100], "between 0 and 9"),
+        (["a"], "between 0 and 9"),
+    ],
+)
+def test_multivariate_imputer_invalid_rows_to_impute_raises(x_valid, rows, match):
+    with pytest.raises(ValueError, match=match):
+        MultivariateImputer()(x_valid, rows_to_impute=rows)
+
+
+@pytest.mark.parametrize("cols", [[10], [-1], ["a"]])
+def test_multivariate_imputer_invalid_cols_to_impute_raises(x_valid, cols):
+    with pytest.raises(ValueError, match="cols_to_impute must be a list of integers between 0 and 2"):
+        MultivariateImputer()(x_valid, cols_to_impute=cols)
+
+
+@pytest.mark.parametrize(
+    "n_nearest_features, match",
+    [
+        (1.5, r"in \(0, 1\]"),
+        (0.0, r"in \(0, 1\]"),
+        (0.05, "resulted in 0 features"),
+        ("two", "int or float"),
+        (0, "between 1 and 3"),
+        (10, "between 1 and 3"),
+    ],
+)
+def test_multivariate_imputer_invalid_n_nearest_features_raises(x_valid, n_nearest_features, match):
+    with pytest.raises(ValueError, match=match):
+        MultivariateImputer()(x_valid, n_nearest_features=n_nearest_features)
+
+
+# ---------------------------------------------------------------------------
+# MultivariateImputer input validation (pandas)
+# ---------------------------------------------------------------------------
+
+
+def test_multivariate_imputer_unknown_row_label_raises():
+    df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]}, index=["r0", "r1"])
+    with pytest.raises(ValueError, match=r"Row labels not found in index: \['r2'\]"):
+        MultivariateImputer()(df, rows_to_impute=["r2"])
+
+
+def test_multivariate_imputer_unknown_column_label_raises():
+    df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+    with pytest.raises(ValueError, match=r"Column labels not found in columns: \['c'\]"):
+        MultivariateImputer()(df, cols_to_impute=["c"])
+
+
+# ---------------------------------------------------------------------------
+# TimeSeriesImputer configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lags", [1, ["a"], [1.5]])
+def test_timeseries_imputer_lags_must_be_iterable_of_ints(lags):
+    with pytest.raises(ValueError, match="lags must be an iterable of integers"):
+        TimeSeriesImputer(lags=lags)
+
+
+def test_timeseries_imputer_time_column_must_be_string_or_none():
+    with pytest.raises(ValueError, match="string or None"):
+        TimeSeriesImputer(time_column=1)
+
+    imputer = TimeSeriesImputer()
+    with pytest.raises(ValueError, match="string or None"):
+        imputer.set_params(time_column=1)
+
+
+# ---------------------------------------------------------------------------
+# TimeSeriesImputer input validation
+# ---------------------------------------------------------------------------
+
+
+def _ts_frame(periods=30):
+    index = pd.date_range("2024-01-01", periods=periods, freq="D")
+    values = np.arange(periods, dtype=np.float64)
+    values[3] = np.nan
+    return pd.DataFrame({"value": values, "other": values + 1.0}, index=index)
+
+
+def test_timeseries_imputer_rejects_non_dataframe():
+    with pytest.raises(TypeError, match="pandas or eager Polars"):
+        TimeSeriesImputer()(np.zeros((5, 2)))
+
+
+def test_timeseries_imputer_rejects_non_datetime_index():
+    with pytest.raises(TypeError, match="DatetimeIndex"):
+        TimeSeriesImputer()(pd.DataFrame({"a": [1.0, 2.0]}))
+
+
+@pytest.mark.parametrize(
+    "timestamps, match",
+    [
+        (["2024-01-01"], "at least two timestamps"),
+        (["2024-01-02", "2024-01-01"], "sorted in increasing order"),
+        (["2024-01-01", "2024-01-01"], "duplicate timestamps"),
+        (["2024-01-01", "2024-01-02", "2024-01-03 12:00"], "irregular timestamp gaps"),
+    ],
+)
+def test_timeseries_imputer_invalid_index_raises(timestamps, match):
+    index = pd.DatetimeIndex(timestamps)
+    df = pd.DataFrame({"a": np.ones(len(index))}, index=index)
+    with pytest.raises(ValueError, match=match):
+        TimeSeriesImputer()(df)
+
+
+def test_timeseries_imputer_invalid_cols_to_impute_type_raises():
+    with pytest.raises(ValueError, match="int, str, or an iterable"):
+        TimeSeriesImputer()(_ts_frame(), cols_to_impute=[1.5])
+
+
+def test_timeseries_imputer_rejects_non_numeric_columns():
+    df = _ts_frame()
+    df["label"] = list("ab" * 15)
+    with pytest.raises(ValueError, match="requires numeric columns"):
+        TimeSeriesImputer()(df)
+
+
+def test_interpolate_small_gaps_requires_int():
+    series = pd.Series([1.0, np.nan, 3.0])
+    with pytest.raises(TypeError, match="n must be an int"):
+        interpolate_small_gaps(series, 1.5)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.linear_model import Ridge
+from sklearn.tree import DecisionTreeClassifier
 
 import datafiller.multivariate.imputer as multivariate_imputer_module
 from datafiller.datasets import load_titanic
@@ -179,6 +181,34 @@ def test_multivariate_imputer_set_params_resolves_default_min_samples_train():
     imputer = MultivariateImputer(min_samples_train=1)
     imputer.set_params(min_samples_train=None)
     assert imputer.min_samples_train == 20
+
+
+def test_multivariate_imputer_set_params_resets_default_regressor_and_classifier():
+    imputer = MultivariateImputer()
+
+    custom_regressor = Ridge()
+    imputer.set_params(regressor=custom_regressor)
+    assert imputer.regressor is custom_regressor
+    imputer.set_params(regressor=None)
+    assert isinstance(imputer.regressor, FastRidge)
+
+    custom_classifier = DecisionTreeClassifier(max_depth=2)
+    imputer.set_params(classifier=custom_classifier)
+    assert imputer.classifier is custom_classifier
+    imputer.set_params(classifier=None)
+    assert isinstance(imputer.classifier, DecisionTreeClassifier)
+    assert imputer.classifier.max_depth == 4
+
+
+def test_multivariate_imputer_set_params_rng_refreshes_default_classifier():
+    imputer = MultivariateImputer()
+    imputer.set_params(rng=7)
+    assert imputer.classifier.random_state == 7
+
+    custom_classifier = DecisionTreeClassifier(max_depth=2, random_state=0)
+    imputer.set_params(classifier=custom_classifier, rng=3)
+    assert imputer.classifier is custom_classifier
+    assert imputer.classifier.random_state == 0
 
 
 def test_multivariate_imputer_fallback_fills_with_column_mean(nan_array):

--- a/tests/test_multivariate_polars.py
+++ b/tests/test_multivariate_polars.py
@@ -96,3 +96,17 @@ def test_multivariate_imputer_polars_matches_numpy_for_numeric_data():
     actual = MultivariateImputer(min_samples_train=10)(pl.DataFrame(values, schema=["a", "b"]))
 
     np.testing.assert_allclose(actual.to_numpy(), expected)
+
+
+def test_multivariate_imputer_polars_invalid_selectors_raise():
+    df = pl.DataFrame({"a": [1.0, None, 3.0], "b": [4.0, 5.0, 6.0]})
+    imputer = MultivariateImputer()
+
+    with pytest.raises(ValueError, match="column names as strings"):
+        imputer(df, cols_to_impute=[0])
+    with pytest.raises(ValueError, match=r"Column names not found in Polars DataFrame: \['c'\]"):
+        imputer(df, cols_to_impute=["c"])
+    with pytest.raises(ValueError, match="integer row positions for a Polars DataFrame"):
+        imputer(df, rows_to_impute="a")
+    with pytest.raises(ValueError, match="integer row positions between 0 and 2"):
+        imputer(df, rows_to_impute=[0, 5])

--- a/tests/test_timeseries_polars.py
+++ b/tests/test_timeseries_polars.py
@@ -86,3 +86,33 @@ def test_timeseries_imputer_polars_preserves_date_column_dtype():
 
     assert imputed.schema["date"] == pl.Date
     assert imputed.height == 5
+
+
+def test_timeseries_imputer_polars_validates_time_values_and_columns():
+    timestamps = [datetime(2024, 1, 1) + timedelta(hours=i) for i in range(6)]
+
+    with_null_time = pl.DataFrame({"timestamp": timestamps[:5] + [None], "value": np.arange(6, dtype=float)})
+    with pytest.raises(ValueError, match="cannot contain null values"):
+        TimeSeriesImputer(time_column="timestamp")(with_null_time)
+
+    time_only = pl.DataFrame({"timestamp": timestamps})
+    with pytest.raises(ValueError, match="at least one data column"):
+        TimeSeriesImputer(time_column="timestamp")(time_only)
+
+    with_string_column = pl.DataFrame(
+        {"timestamp": timestamps, "value": np.arange(6, dtype=float), "label": list("abcdef")}
+    )
+    with pytest.raises(ValueError, match=r"unsupported columns: \['label'\]"):
+        TimeSeriesImputer(time_column="timestamp")(with_string_column)
+
+
+def test_timeseries_imputer_polars_invalid_selectors_raise():
+    df = _polars_time_series()
+    imputer = TimeSeriesImputer(time_column="timestamp")
+
+    with pytest.raises(ValueError, match="must contain column names"):
+        imputer(df, cols_to_impute=[0])
+    with pytest.raises(ValueError, match="time_column cannot be imputed"):
+        imputer(df, cols_to_impute=["timestamp", "value"])
+    with pytest.raises(ValueError, match="not found in the regularized time grid"):
+        imputer(df, rows_to_impute=[datetime(2030, 1, 1)])


### PR DESCRIPTION
## Summary
- ~50 new tests: parametrized error-path coverage for every user-facing validation error, functional tests for the `datasets` missingness helpers, Polars selector errors, and `set_params` default-component behavior (133 tests total)
- Ships `py.typed` (PEP 561) with typecheck-clean annotations (`ty check` passes: fixed implicit-Optional default, None-inferred attributes, selector unions; explicit asserts for flag-correlated narrowing)
- New `DataFillerError` hierarchy: `DataFillerValueError`/`DataFillerTypeError` also inherit the matching builtins, so existing `except ValueError` handlers keep working
- CI: triggers on pushes to main; new coverage job (`NUMBA_DISABLE_JIT=1` so numba kernels are traced, 87% measured, gated at 85); new type-check job with pinned `ty==0.0.61`
- Classifiers: Production/Stable, Python 3.14, `Typing :: Typed`

## Test plan
- [x] `pytest` — 133 passed (including CUDA GPU tests locally)
- [x] `NUMBA_DISABLE_JIT=1 pytest` — 131 passed (timing tests skipped)
- [x] `ty check src/datafiller` — clean
- [x] `ruff check` / `ruff format --check` — clean
- [x] `py.typed` verified present in built wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)